### PR TITLE
bugfix: Update Gaussian calculation in FractControllerAcuityVernier

### DIFF
--- a/FractControllerAcuityVernier.j
+++ b/FractControllerAcuityVernier.j
@@ -56,7 +56,7 @@ Created by Bach on 14.08.2017.
     const backGray = [MiscLight upperLuminanceFromContrastMilsn: [MiscLight contrastMichelsonPercentFromWeberPercent: [Settings contrastAcuityWeber]]];
     const cnt = [Settings contrastAcuityWeber] / 100;
     for (let ix = ix0 - iSigma; ix <= ix0 + iSigma; ix++) {
-        const gaussValue = Math.exp(-Math.pow(x0 - ix, 2) / sigma);
+        const gaussValue = Math.exp(-0.5 * Math.pow((x0 - ix) / sigma, 2));
         const grayValue = [MiscLight devicegrayFromLuminance: backGray - cnt * gaussValue];
         CGContextSetStrokeColor(cgc, [CPColor colorWithWhite: grayValue alpha: 1]);
         CGContextBeginPath(cgc);


### PR DESCRIPTION
Dear Prof. Dr. Bach,

First of all: Huge fan of your work. Thank you especially for creating FrACT, which is one of the bedrocks of our research!
\---
While empirically testing the widths of the lines displayed in the Vernier acuity test, it appeared to me that the measured width of the lines were not linearly varying in the **width $\sigma$** parameter set in the settings pane. In fact, it quite faithfully followed the form $width = a \sqrt\sigma$. I found this behavior counterintuitive.

<img width="1185" height="473" alt="grafik" src="https://github.com/user-attachments/assets/dece04da-4829-4bb8-8027-51d3d1724dfe" />

It seems line 59 in [FractControllerAcuityVernier.j](https://github.com/michaelbach/FrACT10/compare/main...suddhasourav:FrACT10_vernier_acuity_linearize_gaussian_sigma?expand=1#diff-feb90393ab8e203ce3975b021ee12e3608a0654f9ba644ef1e0fa327a87212a2) might offer an explanation: currently, the gaussian profile of the line seems to be coded as $y = e^{-\frac{(x - x_0)^2}{\sigma}}$, whereas the standard form would be $y = e^{-\frac{1}{2}\left(\frac{x - x_0}{\sigma}\right)^2}$.

With the present change, the empirical width is linear and is virtually exactly spans $\pm 3 \sigma$:

<img width="1190" height="466" alt="grafik" src="https://github.com/user-attachments/assets/c602a8c2-ee64-400c-9d00-cbec44ff8e66" />

(For empirical measurement, I defined width as the number of pixels different by at least an amount of 0.001 from the background)